### PR TITLE
Grif style updates

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -10,7 +10,7 @@
     <ul class="navbar-nav">
       {% for module in site.data.course.modules %}
        {% assign first_post = site.categories[module]|reverse|first %}
-       <li class="nav-item py-0{% if page.categories[1] == module %} active{% endif %}">
+       <li class="nav-item py-2{% if page.categories[1] == module %} active{% endif %}">
          <a class="nav-link" href="{{ site.baseurl }}{{ first_post.url }}">
            {{ module }}
          </a>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -7,7 +7,7 @@ body {
 
 @include media-breakpoint-up(md) {
   .navbar {
-    line-height: 3;
+    //line-height: 3;
   }
 }
 
@@ -101,6 +101,7 @@ section {
 }
 
 .sidebar li {
+	padding-right: 1em;
 	position: relative;
 	@include transition(color, 0.3s, linear);
 }


### PR DESCRIPTION
- Got rid of line-height that was giving navbar items their height, which caused large line spacing on module titles for narrow screens before navbar collapse; added height back in li vertical padding
- Adding right padding to sidebar li